### PR TITLE
Added requied dependency to git

### DIFF
--- a/debian/DEBIAN/control.default
+++ b/debian/DEBIAN/control.default
@@ -7,7 +7,7 @@ Version: {{ VERSION }}
 Section: php
 Installed-Size: 9216
 Architecture: all
-Depends: php5
+Depends: php5,git
 Description: Dependency Manager for PHP.
  Composer is a tool for dependency management in PHP. It allows you to declare
  the dependent libraries your project needs and it will install them in your


### PR DESCRIPTION
Hallo, 
on fresh installed debian:

```
    Failed to download xxx/yyyy from source: Failed to clone git@github.com:xxxx/yyy.git, git was not found, check that it is installed and in your PATH env.

sh: 1: git: not found
```